### PR TITLE
Store comments as entities in Datastore

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -28,6 +28,11 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
+  private ArrayList<String> comments = new ArrayList<String>(Arrays.asList());
   private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
   
   @Override
@@ -42,6 +43,7 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String newComment = request.getParameter("new-comment");
     if (!newComment.isEmpty()){
+      this.comments.add(newComment);
       Entity commentEntity = new Entity("Comment");
       commentEntity.setProperty("content", newComment);
       this.datastore.put(commentEntity);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -15,6 +15,9 @@
 package com.google.sps.servlets;
 
 import com.google.gson.Gson;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,6 +31,7 @@ import javax.servlet.http.HttpServletResponse;
 public class DataServlet extends HttpServlet {
   private ArrayList<String> comments = new ArrayList<String>( 
     Arrays.asList());
+  private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -40,6 +44,9 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String newComment = request.getParameter("new-comment");
     if (!newComment.isEmpty()){
+      Entity commentEntity = new Entity("Comment");
+      commentEntity.setProperty("content", newComment);
+      this.datastore.put(commentEntity);
       this.comments.add(newComment);
     }
     response.sendRedirect("/index.html");

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -29,8 +29,6 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
-  private ArrayList<String> comments = new ArrayList<String>( 
-    Arrays.asList());
   private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
   
   @Override
@@ -47,7 +45,6 @@ public class DataServlet extends HttpServlet {
       Entity commentEntity = new Entity("Comment");
       commentEntity.setProperty("content", newComment);
       this.datastore.put(commentEntity);
-      this.comments.add(newComment);
     }
     response.sendRedirect("/index.html");
   }


### PR DESCRIPTION
Comments stored locally in an `ArrayList` are erased when the server restarts or scales. A safer, more persistent way to store the data is in a database (`Datastore` service in this case). To achieve this, two files are touched: 

- pom.xml: add google.appengine dependency to use `Datastore` service. 
- DataServlet.java: create, store and load comments as datastore entities. 

(Week 3 Step 5)