### PR TITLE
Show limited number of comments

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -34,9 +34,9 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
   private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-  static final private String ERR_MSG = "Comment limit must be a non-negative integer.";
-  static final private int MAX_NUM_COMMENTS = 999999;
-  static private int num_comments = 0;
+  static final private String ERR_MSG = 
+    "Comment limit must be a non-negative integer, and do not exceed the maximum.";
+  static final private int MAX_LIMIT_COMMENTS = 50;
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -49,6 +49,10 @@ public class DataServlet extends HttpServlet {
       return;
     }
     if (limit<0){
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, ERR_MSG);
+      return;
+    }
+    if (limit>this.MAX_LIMIT_COMMENTS){
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, ERR_MSG);
       return;
     }
@@ -67,12 +71,7 @@ public class DataServlet extends HttpServlet {
   }
 
   @Override
-  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    if (this.num_comments>=this.MAX_NUM_COMMENTS){
-      response.sendError(HttpServletResponse.SC_CONFLICT, "Exceeds maximum number of comments.");
-      return;
-    }
-    
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {    
     String newComment = request.getParameter("new-comment");
     long timestamp = System.currentTimeMillis();
 
@@ -85,6 +84,5 @@ public class DataServlet extends HttpServlet {
     commentEntity.setProperty("content", newComment);
     commentEntity.setProperty("timestamp", timestamp);
     this.datastore.put(commentEntity);
-    this.num_comments+=1;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -37,12 +37,7 @@ public class DataServlet extends HttpServlet {
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String limitStr = request.getParameter("limit");
-    int limit = 3; // Default number of comments shown. 
-    if (limitStr!=null && limitStr!=""){
-      limit = Integer.parseInt(limitStr);
-    }
-    // TODO there should be a better way of writing this ^
+    int limit = Integer.parseInt(request.getParameter("limit"));
 
     Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
     PreparedQuery pq = this.datastore.prepare(query);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -37,6 +37,7 @@ public class DataServlet extends HttpServlet {
   static final private String ERR_MSG = 
     "Comment limit must be a non-negative integer, and do not exceed the maximum.";
   static final private int MAX_LIMIT_COMMENTS = 50;
+  static final private int MAX_CHAR_PER_COMMENT = 280;
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -73,12 +74,16 @@ public class DataServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {    
     String newComment = request.getParameter("new-comment");
-    long timestamp = System.currentTimeMillis();
-
     if (newComment == null || newComment.isEmpty()){
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Comment must be a non-empty string.");
       return;
     }
+
+    if (newComment.length() > this.MAX_CHAR_PER_COMMENT){
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Comment is too long.");
+      return;
+    }
+    long timestamp = System.currentTimeMillis();
     
     Entity commentEntity = new Entity("Comment");
     commentEntity.setProperty("content", newComment);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -37,6 +37,7 @@ public class DataServlet extends HttpServlet {
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Integer guaranteed in script.js
     int limit = Integer.parseInt(request.getParameter("limit"));
 
     Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
@@ -59,13 +60,12 @@ public class DataServlet extends HttpServlet {
 
     if (newComment.isEmpty()){
       response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+      return;
     }
-    else{
-      Entity commentEntity = new Entity("Comment");
-      commentEntity.setProperty("content", newComment);
-      commentEntity.setProperty("timestamp", timestamp);
-      this.datastore.put(commentEntity);
-      response.sendRedirect("/index.html");
-    }
+    Entity commentEntity = new Entity("Comment");
+    commentEntity.setProperty("content", newComment);
+    commentEntity.setProperty("timestamp", timestamp);
+    this.datastore.put(commentEntity);
+    response.sendRedirect("/index.html");
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -38,15 +38,16 @@ public class DataServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     int limit = 3;
+    String ERR_MSG = "Comment limit must be a non-negative integer.";
     try {
       limit = Integer.parseInt(request.getParameter("limit"));
     }
     catch(NumberFormatException e){
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST,"Comment limit must be an integer.");
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, ERR_MSG);
       return;
     }
     if (limit<0){
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Comment limit must be a non-negative integer");
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, ERR_MSG);
       return;
     }
 
@@ -67,8 +68,9 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String newComment = request.getParameter("new-comment");
     long timestamp = System.currentTimeMillis();
+    System.out.println("new comment received: "+newComment);
 
-    if (newComment.isEmpty()){
+    if (newComment == null || newComment.isEmpty()){
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Comment must be a non-empty string.");
       return;
     }
@@ -76,6 +78,5 @@ public class DataServlet extends HttpServlet {
     commentEntity.setProperty("content", newComment);
     commentEntity.setProperty("timestamp", timestamp);
     this.datastore.put(commentEntity);
-    response.sendRedirect("/index.html");
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -69,7 +69,7 @@ public class DataServlet extends HttpServlet {
     long timestamp = System.currentTimeMillis();
 
     if (newComment.isEmpty()){
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Comment must be a non-empty string.");
       return;
     }
     Entity commentEntity = new Entity("Comment");

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -37,8 +37,18 @@ public class DataServlet extends HttpServlet {
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    // Integer guaranteed in script.js
-    int limit = Integer.parseInt(request.getParameter("limit"));
+    int limit;
+    try {
+      limit = Integer.parseInt(request.getParameter("limit"));
+    }
+    catch(NumberFormatException e){
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Comment limit must be an integer.");
+      return;
+    }
+    if (limit<0){
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Comment limit must be a non-negative integer");
+      return;
+    }
 
     Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
     PreparedQuery pq = this.datastore.prepare(query);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -37,10 +37,17 @@ public class DataServlet extends HttpServlet {
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String limitStr = request.getParameter("limit");
+    int limit = 3; // Default number of comments shown. 
+    if (limitStr!=null && limitStr!=""){
+      limit = Integer.parseInt(limitStr);
+    }
+    // TODO there should be a better way of writing this ^
+    
     Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
     PreparedQuery pq = this.datastore.prepare(query);
 
-    List<String> comments = pq.asList(FetchOptions.Builder.withLimit(3))
+    List<String> comments = pq.asList(FetchOptions.Builder.withLimit(limit))
       .stream()
       .map(entity->(String) entity.getProperty("content"))
       .collect(Collectors.toList());

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -35,6 +35,8 @@ import javax.servlet.http.HttpServletResponse;
 public class DataServlet extends HttpServlet {
   private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
   static final private String ERR_MSG = "Comment limit must be a non-negative integer.";
+  static final private int MAX_NUM_COMMENTS = 999999;
+  static private int num_comments = 0;
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -66,6 +68,11 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    if (this.num_comments>=this.MAX_NUM_COMMENTS){
+      response.sendError(HttpServletResponse.SC_CONFLICT, "Exceeds maximum number of comments.");
+      return;
+    }
+    
     String newComment = request.getParameter("new-comment");
     long timestamp = System.currentTimeMillis();
 
@@ -78,5 +85,6 @@ public class DataServlet extends HttpServlet {
     commentEntity.setProperty("content", newComment);
     commentEntity.setProperty("timestamp", timestamp);
     this.datastore.put(commentEntity);
+    this.num_comments+=1;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -34,11 +34,11 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
   private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-  
+  static final private String ERR_MSG = "Comment limit must be a non-negative integer.";
+
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     int limit = 3;
-    String ERR_MSG = "Comment limit must be a non-negative integer.";
     try {
       limit = Integer.parseInt(request.getParameter("limit"));
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -43,7 +43,7 @@ public class DataServlet extends HttpServlet {
       limit = Integer.parseInt(limitStr);
     }
     // TODO there should be a better way of writing this ^
-    
+
     Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
     PreparedQuery pq = this.datastore.prepare(query);
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -34,10 +34,10 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
   private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-  static final private String ERR_MSG = 
-    "Comment limit must be a non-negative integer, and do not exceed the maximum.";
-  static final private int MAX_LIMIT_COMMENTS = 50;
-  static final private int MAX_CHAR_PER_COMMENT = 280;
+  final private int MAX_LIMIT_COMMENTS = 50;
+  final private int MAX_CHAR_PER_COMMENT = 280;
+  final private String ERR_MSG = 
+    String.format("Comment limit must be a non-negative integer, and do not exceed %d.", this.MAX_LIMIT_COMMENTS);
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -80,7 +80,8 @@ public class DataServlet extends HttpServlet {
     }
 
     if (newComment.length() > this.MAX_CHAR_PER_COMMENT){
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Comment is too long.");
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, 
+        String.format("Comment must have fewer than %d characters.", this.MAX_CHAR_PER_COMMENT));
       return;
     }
     long timestamp = System.currentTimeMillis();

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -68,12 +68,12 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String newComment = request.getParameter("new-comment");
     long timestamp = System.currentTimeMillis();
-    System.out.println("new comment received: "+newComment);
 
     if (newComment == null || newComment.isEmpty()){
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Comment must be a non-empty string.");
       return;
     }
+    
     Entity commentEntity = new Entity("Comment");
     commentEntity.setProperty("content", newComment);
     commentEntity.setProperty("timestamp", timestamp);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -37,12 +37,12 @@ public class DataServlet extends HttpServlet {
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    int limit;
-    try {
-      limit = Integer.parseInt(request.getParameter("limit"));
+    int limit = 3;
+    try {
+      limit = Integer.parseInt(request.getParameter("limit"));
     }
-    catch(NumberFormatException e){
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Comment limit must be an integer.");
+    catch(NumberFormatException e){
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST,"Comment limit must be an integer.");
       return;
     }
     if (limit<0){

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -66,6 +66,7 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String newComment = request.getParameter("new-comment");
     long timestamp = System.currentTimeMillis();
 
     if (newComment == null || newComment.isEmpty()){

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -41,7 +41,7 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    int limit = 3;
+    int limit;
     try {
       limit = Integer.parseInt(request.getParameter("limit"));
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -66,7 +66,6 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String newComment = request.getParameter("new-comment");
     long timestamp = System.currentTimeMillis();
 
     if (newComment == null || newComment.isEmpty()){

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -20,13 +20,12 @@
     <ul>Guilty pleasure: binge-watch The Big Bang Theory</ul>
     <ul>Fun fact: ❤raw carrots ⛔cooked carrots</ul>
     <br>
-    <h2>Where am I?</h2>
-    <button onclick="findZoe()">Find Zoe</button>
+    <h2>Where am I? <button onclick="findZoe()">Find Zoe</button></h2>
     <div id="link-container">
       <a id="link"></a>
     </div>
     <br>
-    <h2>Help me <button onclick="grow()"><b>Grow</b></button></h2>
+    <h2>Help me <button onclick="grow()">Grow</button></h2>
     <img id="basil" />
     <p id="endMsg"></p>
     <br>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -30,10 +30,10 @@
     <p id="endMsg"></p>
     <br>
     <h2>Comments</h2>
-    <form action="/data" method="POST">
+    <form>
       <label>Leave a comment </label>
       <input type="text" id="new-comment" name="new-comment">
-      <input type="submit">
+      <button type="button" onclick="submitComment()">Submit</button>  
     </form>
     <br>
     <form>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -37,9 +37,13 @@
       <input type="submit">
     </form>
     <br>
-    <label>Display the latest comments (between 1 and 100)</label>      
-    <input type="number" id="limit" name="quantity" min="1" max="100" placeholder="3">
-    <button type="button" onclick="getComments()">Refresh</button>
+    <label>Display the latest comments </label>
+    <select name="limit" id="limit">
+      <option value="3" selected="selected">3</option>
+      <option value="10">10</option>
+      <option value="20">20</option>
+    </select>
+    <button type="button" onclick="getComments()">Refresh</button>    
     <ul id="comments-container"></ul>
 </body>
 

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -33,7 +33,7 @@
     <form>
       <label>Leave a comment </label>
       <input type="text" id="new-comment" name="new-comment">
-      <button type="button" onclick="submitComment()">Submit</button>  
+      <button type="button" onclick="submitComment()">Submit</button>
     </form>
     <br>
     <form>
@@ -43,8 +43,8 @@
         <option value="10">10</option>
         <option value="20">20</option>
       </select>
-      <button type="button" onclick="getComments()">Refresh</button>  
-    </form>  
+      <button type="button" onclick="getComments()">Refresh</button>
+    </form>
     <ul id="comments-container"></ul>
 </body>
 

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -34,7 +34,12 @@
     <form action="/data" method="POST">
       <p>Add a new comment: </p>
       <input type="text" id="new-comment" name="new-comment">
-      <input type="submit" />
+      <input type="submit">
+    </form>
+    <form action="/limit" method="POST">
+      <p>Limit the number of comments shown to: (between 1 and 100)</p>      
+      <input type="number" id="limit" name="quantity" min="1" max="100" placeholder="3">
+      <button type="button" onclick="getComments()">Refresh</button>
     </form>
     <ul id="comments-container"></ul>
 </body>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -36,13 +36,15 @@
       <input type="submit">
     </form>
     <br>
-    <label>Display the latest comments </label>
-    <select name="limit" id="limit">
-      <option value="3" selected="selected">3</option>
-      <option value="10">10</option>
-      <option value="20">20</option>
-    </select>
-    <button type="button" onclick="getComments()">Refresh</button>    
+    <form>
+      <label>Display the latest comments </label>
+      <select name="limit" id="limit">
+        <option value="3" selected="selected">3</option>
+        <option value="10">10</option>
+        <option value="20">20</option>
+      </select>
+      <button type="button" onclick="getComments()">Refresh</button>  
+    </form>  
     <ul id="comments-container"></ul>
 </body>
 

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -32,15 +32,14 @@
     <br>
     <h2>Comments</h2>
     <form action="/data" method="POST">
-      <p>Add a new comment: </p>
+      <label>Leave a comment </label>
       <input type="text" id="new-comment" name="new-comment">
       <input type="submit">
     </form>
-    <form action="/limit" method="POST">
-      <p>Limit the number of comments shown to: (between 1 and 100)</p>      
-      <input type="number" id="limit" name="quantity" min="1" max="100" placeholder="3">
-      <button type="button" onclick="getComments()">Refresh</button>
-    </form>
+    <br>
+    <label>Display the latest comments (between 1 and 100)</label>      
+    <input type="number" id="limit" name="quantity" min="1" max="100" placeholder="3">
+    <button type="button" onclick="getComments()">Refresh</button>
     <ul id="comments-container"></ul>
 </body>
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -65,7 +65,8 @@ function grow() {
 }
 
 function getComments() {
-  fetch('/data').then(response => response.json()).then(comments => {
+  const limit=document.getElementById("limit").value;
+  fetch(`/data?limit=${limit}`).then(response => response.json()).then(comments => {
     const commentsContainer = document.getElementById('comments-container');
     for (const comment of comments){
       const commentElement = document.createElement('li');

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -72,7 +72,7 @@ function getComments() {
   }
   // Read user input, show 3 comments in default
   var limit = document.getElementById("limit").value;
-  if (limit==null || limit==""){
+  if (limit==null || limit===""){
     limit="3";
   }
   

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -65,9 +65,19 @@ function grow() {
 }
 
 function getComments() {
-  const limit=document.getElementById("limit").value;
-  fetch(`/data?limit=${limit}`).then(response => response.json()).then(comments => {
-    const commentsContainer = document.getElementById('comments-container');
+  const commentsContainer = document.getElementById('comments-container');
+  // Clear all comments
+  while (commentsContainer.firstChild) {
+    commentsContainer.firstChild.remove();
+  }
+  // Read user input, set default to be 3 comments
+  var limit = document.getElementById("limit").value;
+  if (limit==null || limit==""){
+    limit="3";
+  }
+  const url = `/data?limit=${limit}`;
+  
+  fetch(url).then(response => response.json()).then(comments => {
     for (const comment of comments){
       const commentElement = document.createElement('li');
       commentElement.innerText = comment;

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -85,7 +85,6 @@ function getComments() {
 
 function submitComment(){
   const newComment = document.getElementById('new-comment').value;
-  console.log("get new element: "+newComment);
   const request = new Request(`/data?new-comment=${newComment}`, {method:'POST'});
   fetch(request).then(()=>getComments());
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -70,8 +70,7 @@ function getComments() {
   while (commentsContainer.firstChild) {
     commentsContainer.firstChild.remove();
   }
-  // Read user input, show 3 comments in default
-  var limit = document.getElementById("limit").value;
+  const limit = document.getElementById("limit").value;
   
   fetch(`/data?limit=${limit}`)
     .then(response => response.json())

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -71,11 +71,11 @@ function getComments() {
     commentsContainer.firstChild.remove();
   }
   const limit = document.getElementById("limit").value;
-  
+
   fetch(`/data?limit=${limit}`)
     .then(response => response.json())
     .then(comments => {
-      for (const comment of comments){
+      for (const comment of comments) {
         const commentElement = document.createElement('li');
         commentElement.innerText = comment;
         commentsContainer.appendChild(commentElement);
@@ -83,8 +83,8 @@ function getComments() {
     });
 }
 
-function submitComment(){
+function submitComment() {
   const newComment = document.getElementById('new-comment').value;
-  const request = new Request(`/data?new-comment=${newComment}`, {method:'POST'});
-  fetch(request).then(()=>getComments());
+  const request = new Request(`/data?new-comment=${newComment}`, { method: 'POST' });
+  fetch(request).then(() => getComments());
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -72,9 +72,6 @@ function getComments() {
   }
   // Read user input, show 3 comments in default
   var limit = document.getElementById("limit").value;
-  if (limit==null || limit===""){
-    limit="3";
-  }
   
   fetch(`/data?limit=${limit}`)
     .then(response => response.json())

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -82,3 +82,10 @@ function getComments() {
       }
     });
 }
+
+function submitComment(){
+  const newComment = document.getElementById('new-comment').value;
+  console.log("get new element: "+newComment);
+  const request = new Request(`/data?new-comment=${newComment}`, {method:'POST'});
+  fetch(request).then(()=>getComments());
+}

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -66,22 +66,23 @@ function grow() {
 
 function getComments() {
   const commentsContainer = document.getElementById('comments-container');
-  // Clear all comments
+  // Clear all old comments
   while (commentsContainer.firstChild) {
     commentsContainer.firstChild.remove();
   }
-  // Read user input, set default to be 3 comments
+  // Read user input, show 3 comments in default
   var limit = document.getElementById("limit").value;
   if (limit==null || limit==""){
     limit="3";
   }
-  const url = `/data?limit=${limit}`;
   
-  fetch(url).then(response => response.json()).then(comments => {
-    for (const comment of comments){
-      const commentElement = document.createElement('li');
-      commentElement.innerText = comment;
-      commentsContainer.appendChild(commentElement);
-    }
-  });
+  fetch(`/data?limit=${limit}`)
+    .then(response => response.json())
+    .then(comments => {
+      for (const comment of comments){
+        const commentElement = document.createElement('li');
+        commentElement.innerText = comment;
+        commentsContainer.appendChild(commentElement);
+      }
+    });
 }


### PR DESCRIPTION
In case of the comment section taking up too much space, users can now choose to display only the latest 3/10/20 comments (default to 3). 

One issue is that when the user submit a comment, the page automatically displays the default latest 3 comments, regardless of the user's previous setting. 

[preview](https://czz-step-2020.appspot.com/)
(Week 3 Step 6 Part 1)