### PR TITLE
Fix bug that causes ClassCastException

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -76,7 +76,7 @@ public class DataServlet extends HttpServlet {
               (long) entity.getKey().getId(),
               (long) entity.getProperty("likeCount"),
               (String) entity.getProperty("email"),
-              (float) entity.getProperty("sentimentScore"))
+              (float)(double) entity.getProperty("sentimentScore"))
           )
       .collect(Collectors.toList());
     


### PR DESCRIPTION
If the returned value [getProperty()](https://cloud.google.com/appengine/docs/standard/java/javadoc/com/google/appengine/api/datastore/PropertyContainer.html#setProperty-java.lang.String-java.lang.Object-)  is only casted to `float`, 
"ClassCastException: java.lang.Double cannot be cast to java.lang.Float" will be thrown when deployed. 

Pretty sure [sentiment.getScore()](https://googleapis.dev/java/google-cloud-language/latest/index.html) returns a float.  

... I don't understand why ... maybe some auto conversion in datastore? 