### PR TITLE
Tdd: add tests for optional attendees

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -418,5 +418,32 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
+
+  @Test
+  public void eventsUnordered() {
+    // The order of events should not make a difference
+    // Events  :       |--A--|     |--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_B)),
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_A))
+    );
+
+    MeetingRequest request =
+            new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+                    TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+                    TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
 }
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -293,6 +293,7 @@ public final class FindMeetingQueryTest {
   public void justEnoughRoomOptionalIgnored() {
     // Have one person, but make it so that there is just enough room at one point in the day to
     // have the meeting.
+    // The optional attendee should be ignored, because otherwise no slots are available.
     //
     // Events  : |--A--|     |----A----|
     // Optional:       |-B-|
@@ -319,7 +320,7 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void justEnoughRoomAllOptional() {
-    // Have one person, but make it so that there is just enough room at one point in the day to
+    // Have two  optional attendees, but make it so that there is just enough room at one point in the day to
     // have the meeting.
     //
     // Optional: |--A--|     |----B----|
@@ -393,23 +394,20 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void notEnoughRoomAllOptional() {
-    // Have one person, but make it so that there is not enough room at any point in the day to
+    // Have two optional attendees, but make it so that there is not enough room at any point in the day to
     // have the meeting.
     //
     // Optional: |--A-----| |-----B----|
     // Day     : |---------------------|
     // Options :
 
-    Collection<Event> events =
-            Arrays.asList(
-                    new Event(
-                            "Event 1",
-                            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-                            Arrays.asList(PERSON_A)),
-                    new Event(
-                            "Event 2",
-                            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
-                            Arrays.asList(PERSON_B)));
+    Collection<Event> events = Arrays.asList(
+            new Event("Event 1",
+                    TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                    Arrays.asList(PERSON_A)),
+            new Event("Event 2",
+                    TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                    Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_60_MINUTES);
     request.addOptionalAttendee(PERSON_A);

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -316,6 +316,32 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
+  public void justEnoughRoomAllOptional() {
+    // Have one person, but make it so that there is just enough room at one point in the day to
+    // have the meeting.
+    //
+    // Optional: |--A--|     |----B----|
+    // Day     : |---------------------|
+    // Options :       |-----|
+
+    Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                    Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                    Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
   public void ignoresPeopleNotAttending() {
     // Add an event, but make the only attendee someone different from the person looking to book
     // a meeting. This event should not affect the booking.

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -14,6 +14,7 @@
 
 package com.google.sps;
 
+import java.sql.Time;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -34,6 +35,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -114,9 +116,40 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+                    TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+                    TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void everyAttendeeIsConsideredOptionalBusy() {
+    // Have each person have different events. We should see two options because each person has
+    // split the restricted times.
+    //
+    // Events  :       |--A--|     |--B--|
+    // Optional: |-------------C---------------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_B)),
+            new Event("Event 3", TimeRange.fromStartDuration(TimeRange.START_OF_DAY,
+                    TimeRange.WHOLE_DAY.duration()), Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+            new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+                    TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+                    TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -131,18 +164,18 @@ public final class FindMeetingQueryTest {
     // Options : |--1--|         |--2--|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
-            Arrays.asList(PERSON_B)));
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+                    Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
+                    Arrays.asList(PERSON_B)));
 
     MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+            new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                    TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
   }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -155,6 +155,36 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
+  public void everyAttendeeIsConsideredOptionalFree() {
+    // Have each person have different events. We should see two options because each person has
+    // split the restricted times.
+    //
+    // Events  :       |--A--|     |--B--|
+    // Optional:             |--C--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--2--|
+
+    Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_B)),
+            new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+                    Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+            new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+                    TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
   public void overlappingEvents() {
     // Have an event for each person, but have their events overlap. We should only see two options.
     //

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -126,8 +126,10 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void everyAttendeeIsConsideredOptionalBusy() {
-    // Have each person have different events. We should see two options because each person has
+    // Have each person have different events. We should see three options because each person has
     // split the restricted times.
+    // If we consider the optional attendee, no slots will be available.
+    // So we ignore the optional attendee.
     //
     // Events  :       |--A--|     |--B--|
     // Optional: |-------------C---------------|

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -418,32 +418,5 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
-
-  @Test
-  public void eventsUnordered() {
-    // The order of events should not make a difference
-    // Events  :       |--A--|     |--B--|
-    // Day     : |-----------------------------|
-    // Options : |--1--|     |--2--|     |--3--|
-
-    Collection<Event> events = Arrays.asList(
-            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-                    Arrays.asList(PERSON_B)),
-            new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
-                    Arrays.asList(PERSON_A))
-    );
-
-    MeetingRequest request =
-            new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
-
-    Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-                    TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
-                    TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
-
-    Assert.assertEquals(expected, actual);
-  }
-
 }
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -352,10 +352,40 @@ public final class FindMeetingQueryTest {
     Collection<Event> events = Arrays.asList(
         new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
-            Arrays.asList(PERSON_A)));
+            new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                    Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void notEnoughRoomAllOptional() {
+    // Have one person, but make it so that there is not enough room at any point in the day to
+    // have the meeting.
+    //
+    // Optional: |--A-----| |-----B----|
+    // Day     : |---------------------|
+    // Options :
+
+    Collection<Event> events =
+            Arrays.asList(
+                    new Event(
+                            "Event 1",
+                            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                            Arrays.asList(PERSON_A)),
+                    new Event(
+                            "Event 2",
+                            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_60_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();


### PR DESCRIPTION
This PR adds 5 new unit tests to ensure these functionality of optional attendees. If one or more time slots exists so that both mandatory and optional attendees can attend, return those time slots. Otherwise, return the time slots that fit just the mandatory attendees.

Some diffs are caused by indentations, no need to look into them -- sorry about that! I will try to separate those. 